### PR TITLE
Google pay payment processing adaptation(stripe, braintree, vantiv)

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,4 +115,26 @@ request.gpMerchantName = 'Your Company Name'; // will be displayed in transactio
 request.gpMerchantId = 'XXXXXXXXXXXX'; // obtain it at https://pay.google.com/business/console
 ```
 
+For Stripe, Braintree and Vantiv, you will have to provide more extra parameters, all the parameter information can be found at [google pay for payments](https://developers.google.com/pay/api/android/reference/object#PaymentMethodTokenizationSpecification):
+
+**Stripe**
+```
+request.stripe:version = 'your stripe api version'
+request.stripe:publishableKey = 'your stripe payment processing publishable key'
+```
+
+**Braintree**
+```
+request.braintree:apiVersion = 'your braintree api version'
+request.braintree:sdkVersion = 'your braintree sdk version'
+request.braintree:clientKey = 'your btraintree client key'
+```
+
+**Vantiv**
+```
+request.vantiv:merchantPayPageId = 'your vantiv page id'
+request.vantiv:merchantOrderId = 'order id'
+request.vantiv:merchantTransactionId = 'transactionID'
+```
+
 Also, on Android checking payment availability calling `canMakePayments()` always returns false even if user has a valid card attached to GooglePay.

--- a/README.md
+++ b/README.md
@@ -119,22 +119,22 @@ For Stripe, Braintree and Vantiv, you will have to provide more extra parameters
 
 **Stripe**
 ```
-request.stripe:version = 'your stripe api version'
-request.stripe:publishableKey = 'your stripe payment processing publishable key'
+request.version = 'your stripe api version'
+request.publishableKey = 'your stripe payment processing publishable key'
 ```
 
 **Braintree**
 ```
-request.braintree:apiVersion = 'your braintree api version'
-request.braintree:sdkVersion = 'your braintree sdk version'
-request.braintree:clientKey = 'your btraintree client key'
+request.apiVersion = 'your braintree api version'
+request.sdkVersion = 'your braintree sdk version'
+request.clientKey = 'your btraintree client key'
 ```
 
 **Vantiv**
 ```
-request.vantiv:merchantPayPageId = 'your vantiv page id'
-request.vantiv:merchantOrderId = 'order id'
-request.vantiv:merchantTransactionId = 'transactionID'
+request.merchantPayPageId = 'your vantiv page id'
+request.merchantOrderId = 'order id'
+request.merchantTransactionId = 'transactionID'
 ```
 
 Also, on Android checking payment availability calling `canMakePayments()` always returns false even if user has a valid card attached to GooglePay.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cordova-plugin-apple-pay-google-pay-with-environment",
-  "version": "1.1.6",
+  "version": "1.1.7",
   "description": "Cordova plugin for integrating Apple Pay and Google Pay in modern cordova apps",
   "cordova": {
     "id": "cordova-plugin-apple-pay-google-pay-with-environment",

--- a/src/android/ApplePayGooglePay.java
+++ b/src/android/ApplePayGooglePay.java
@@ -141,7 +141,7 @@ public class ApplePayGooglePay extends CordovaPlugin {
 
             JSONObject paymentDataRequest = getBaseRequest();
             paymentDataRequest.put(
-                    "allowedPaymentMethods", new JSONArray().put(getCardPaymentMethod(gateway, merchantId)));
+                    "allowedPaymentMethods", new JSONArray().put(getCardPaymentMethod(gateway, merchantId, argss)));
             paymentDataRequest.put("transactionInfo", getTransactionInfo(price, currencyCode, countryCode));
             paymentDataRequest.put("merchantInfo",
                     new JSONObject()
@@ -180,7 +180,39 @@ public class ApplePayGooglePay extends CordovaPlugin {
      * @see <a href=
      * "https://developers.google.com/pay/api/android/reference/object#PaymentMethodTokenizationSpecification">PaymentMethodTokenizationSpecification</a>
      */
-    private static JSONObject getGatewayTokenizationSpecification(String gateway, String gatewayMerchantId) throws JSONException {
+    private static JSONObject getGatewayTokenizationSpecification(String gateway, String gatewayMerchantId, JSONObject argss) throws JSONException {
+        if (gateway.equals("stripe")) {
+            return new JSONObject() {{
+                put("type", "PAYMENT_GATEWAY");
+                put("parameters", new JSONObject() {{
+                    put("gateway", gateway);
+                    put("stripe:version", getParam(argss, "stripe:version"));
+                    put("stripe:publishableKey", getParam(argss, "stripe:publishableKey"));
+                }});
+            }};
+        } else if (gateway.equals("braintree")) {
+            return new JSONObject() {{
+                put("type", "PAYMENT_GATEWAY");
+                put("parameters", new JSONObject() {{
+                    put("gateway", gateway);
+                    put("braintree:apiVersion", getParam(argss, "braintree:apiVersion"));
+                    put("braintree:sdkVersion", getParam(argss, "braintree:sdkVersion"));
+                    put("braintree:merchantId", gatewayMerchantId);
+                    put("braintree:clientKey", getParam(argss, "braintree:clientKey"));
+                }});
+            }};
+        } else if (gateway.equals("vantiv")) {
+            return new JSONObject() {{
+                put("type", "PAYMENT_GATEWAY");
+                put("parameters", new JSONObject() {{
+                    put("gateway", gateway);
+                    put("vantiv:merchantPayPageId", getParam(argss, "vantiv:merchantPayPageId"));
+                    put("vantiv:merchantOrderId", getParam(argss, "vantiv:merchantOrderId"));
+                    put("vantiv:merchantTransactionId", getParam(argss, "vantiv:merchantTransactionId"));
+                    put("vantiv:merchantReportGroup", "*web");
+                }});
+            }};
+        }
         return new JSONObject() {{
             put("type", "PAYMENT_GATEWAY");
             put("parameters", new JSONObject() {{
@@ -222,9 +254,9 @@ public class ApplePayGooglePay extends CordovaPlugin {
      * @see <a
      * href="https://developers.google.com/pay/api/android/reference/object#PaymentMethod">PaymentMethod</a>
      */
-    private JSONObject getCardPaymentMethod(String gateway, String gatewayMerchantId) throws JSONException {
+    private JSONObject getCardPaymentMethod(String gateway, String gatewayMerchantId, JSONObject argss) throws JSONException {
         JSONObject cardPaymentMethod = getBaseCardPaymentMethod();
-        cardPaymentMethod.put("tokenizationSpecification", getGatewayTokenizationSpecification(gateway, gatewayMerchantId));
+        cardPaymentMethod.put("tokenizationSpecification", getGatewayTokenizationSpecification(gateway, gatewayMerchantId, argss));
 
         return cardPaymentMethod;
     }

--- a/src/android/ApplePayGooglePay.java
+++ b/src/android/ApplePayGooglePay.java
@@ -139,9 +139,27 @@ public class ApplePayGooglePay extends CordovaPlugin {
             String gpMerchantId = getParam(argss, "gpMerchantId");
             String gpMerchantName = getParam(argss, "gpMerchantName");
 
+                        String par1 = "";
+            String par2 = "";
+            String par3 = "";
+
+
+            if(gateway.equals("stripe")){
+               par1 = getParam(argss, "version");
+               par2 = getParam(argss, "publishableKey");
+            }else if(gateway.equals("braintree")){
+              par1 = getParam(argss, "apiVersion");
+              par2 = getParam(argss, "sdkVersion");
+              par3 = getParam(argss, "clientKey");
+            }else if(gateway.equals("vantiv")){
+              par1 = getParam(argss, "merchantPayPageId");
+              par2 = getParam(argss, "merchantOrderId");
+              par3 = getParam(argss, "merchantTransactionId");
+            }
+
             JSONObject paymentDataRequest = getBaseRequest();
             paymentDataRequest.put(
-                    "allowedPaymentMethods", new JSONArray().put(getCardPaymentMethod(gateway, merchantId, argss)));
+                    "allowedPaymentMethods", new JSONArray().put(getCardPaymentMethod(gateway, merchantId, par1, par2, par3)));
             paymentDataRequest.put("transactionInfo", getTransactionInfo(price, currencyCode, countryCode));
             paymentDataRequest.put("merchantInfo",
                     new JSONObject()
@@ -181,13 +199,13 @@ public class ApplePayGooglePay extends CordovaPlugin {
      * "https://developers.google.com/pay/api/android/reference/object#PaymentMethodTokenizationSpecification">PaymentMethodTokenizationSpecification</a>
      */
     private static JSONObject getGatewayTokenizationSpecification(String gateway, String gatewayMerchantId, JSONObject argss) throws JSONException {
-        if (gateway.equals("stripe")) {
+       if (gateway.equals("stripe")) {
             return new JSONObject() {{
                 put("type", "PAYMENT_GATEWAY");
                 put("parameters", new JSONObject() {{
                     put("gateway", gateway);
-                    put("stripe:version", getParam(argss, "stripe:version"));
-                    put("stripe:publishableKey", getParam(argss, "stripe:publishableKey"));
+                    put("stripe:version", par1);
+                    put("stripe:publishableKey", par2);
                 }});
             }};
         } else if (gateway.equals("braintree")) {
@@ -195,10 +213,10 @@ public class ApplePayGooglePay extends CordovaPlugin {
                 put("type", "PAYMENT_GATEWAY");
                 put("parameters", new JSONObject() {{
                     put("gateway", gateway);
-                    put("braintree:apiVersion", getParam(argss, "braintree:apiVersion"));
-                    put("braintree:sdkVersion", getParam(argss, "braintree:sdkVersion"));
+                    put("braintree:apiVersion", par1);
+                    put("braintree:sdkVersion", par2);
                     put("braintree:merchantId", gatewayMerchantId);
-                    put("braintree:clientKey", getParam(argss, "braintree:clientKey"));
+                    put("braintree:clientKey", par3);
                 }});
             }};
         } else if (gateway.equals("vantiv")) {
@@ -206,9 +224,9 @@ public class ApplePayGooglePay extends CordovaPlugin {
                 put("type", "PAYMENT_GATEWAY");
                 put("parameters", new JSONObject() {{
                     put("gateway", gateway);
-                    put("vantiv:merchantPayPageId", getParam(argss, "vantiv:merchantPayPageId"));
-                    put("vantiv:merchantOrderId", getParam(argss, "vantiv:merchantOrderId"));
-                    put("vantiv:merchantTransactionId", getParam(argss, "vantiv:merchantTransactionId"));
+                    put("vantiv:merchantPayPageId", par1);
+                    put("vantiv:merchantOrderId", par2);
+                    put("vantiv:merchantTransactionId", par3);
                     put("vantiv:merchantReportGroup", "*web");
                 }});
             }};
@@ -254,9 +272,9 @@ public class ApplePayGooglePay extends CordovaPlugin {
      * @see <a
      * href="https://developers.google.com/pay/api/android/reference/object#PaymentMethod">PaymentMethod</a>
      */
-    private JSONObject getCardPaymentMethod(String gateway, String gatewayMerchantId, JSONObject argss) throws JSONException {
+    private JSONObject getCardPaymentMethod(String gateway, String gatewayMerchantId, String par1, String par2, String par3) throws JSONException {
         JSONObject cardPaymentMethod = getBaseCardPaymentMethod();
-        cardPaymentMethod.put("tokenizationSpecification", getGatewayTokenizationSpecification(gateway, gatewayMerchantId, argss));
+        cardPaymentMethod.put("tokenizationSpecification", getGatewayTokenizationSpecification(gateway, gatewayMerchantId, par1, par2, par3));
 
         return cardPaymentMethod;
     }

--- a/src/android/ApplePayGooglePay.java
+++ b/src/android/ApplePayGooglePay.java
@@ -144,17 +144,21 @@ public class ApplePayGooglePay extends CordovaPlugin {
             String par3 = "";
 
 
-            if(gateway.equals("stripe")){
-               par1 = getParam(argss, "version");
-               par2 = getParam(argss, "publishableKey");
-            }else if(gateway.equals("braintree")){
-              par1 = getParam(argss, "apiVersion");
-              par2 = getParam(argss, "sdkVersion");
-              par3 = getParam(argss, "clientKey");
-            }else if(gateway.equals("vantiv")){
-              par1 = getParam(argss, "merchantPayPageId");
-              par2 = getParam(argss, "merchantOrderId");
-              par3 = getParam(argss, "merchantTransactionId");
+            switch (gateway) {
+                case "stripe":
+                par1 = getParam(argss, "stripe:version");
+                par2 = getParam(argss, "stripe:publishableKey");
+                break;
+                case "braintree":
+                par1 = getParam(argss, "braintree:apiVersion");
+                par2 = getParam(argss, "braintree:sdkVersion");
+                par3 = getParam(argss, "braintree:clientKey");
+                break;
+                case "vantiv":
+                par1 = getParam(argss, "vantiv:merchantPayPageId");
+                par2 = getParam(argss, "vantiv:merchantOrderId");
+                par3 = getParam(argss, "vantiv:merchantTransactionId");
+                break;
             }
 
             JSONObject paymentDataRequest = getBaseRequest();
@@ -199,35 +203,36 @@ public class ApplePayGooglePay extends CordovaPlugin {
      * "https://developers.google.com/pay/api/android/reference/object#PaymentMethodTokenizationSpecification">PaymentMethodTokenizationSpecification</a>
      */
     private static JSONObject getGatewayTokenizationSpecification(String gateway, String gatewayMerchantId, JSONObject argss) throws JSONException {
-       if (gateway.equals("stripe")) {
+        switch (gateway) {
+            case "stripe":
             return new JSONObject() {{
                 put("type", "PAYMENT_GATEWAY");
                 put("parameters", new JSONObject() {{
-                    put("gateway", gateway);
-                    put("stripe:version", par1);
-                    put("stripe:publishableKey", par2);
+                put("gateway", gateway);
+                put("stripe:version", par1);
+                put("stripe:publishableKey", par2);
                 }});
             }};
-        } else if (gateway.equals("braintree")) {
+            case "braintree":
             return new JSONObject() {{
                 put("type", "PAYMENT_GATEWAY");
                 put("parameters", new JSONObject() {{
-                    put("gateway", gateway);
-                    put("braintree:apiVersion", par1);
-                    put("braintree:sdkVersion", par2);
-                    put("braintree:merchantId", gatewayMerchantId);
-                    put("braintree:clientKey", par3);
+                put("gateway", gateway);
+                put("braintree:apiVersion", par1);
+                put("braintree:sdkVersion", par2);
+                put("braintree:merchantId", gatewayMerchantId);
+                put("braintree:clientKey", par3);
                 }});
             }};
-        } else if (gateway.equals("vantiv")) {
+            case "vantiv":
             return new JSONObject() {{
                 put("type", "PAYMENT_GATEWAY");
                 put("parameters", new JSONObject() {{
-                    put("gateway", gateway);
-                    put("vantiv:merchantPayPageId", par1);
-                    put("vantiv:merchantOrderId", par2);
-                    put("vantiv:merchantTransactionId", par3);
-                    put("vantiv:merchantReportGroup", "*web");
+                put("gateway", gateway);
+                put("vantiv:merchantPayPageId", par1);
+                put("vantiv:merchantOrderId", par2);
+                put("vantiv:merchantTransactionId", par3);
+                put("vantiv:merchantReportGroup", "*web");
                 }});
             }};
         }

--- a/src/android/ApplePayGooglePay.java
+++ b/src/android/ApplePayGooglePay.java
@@ -139,25 +139,25 @@ public class ApplePayGooglePay extends CordovaPlugin {
             String gpMerchantId = getParam(argss, "gpMerchantId");
             String gpMerchantName = getParam(argss, "gpMerchantName");
 
-                        String par1 = "";
+            String par1 = "";
             String par2 = "";
             String par3 = "";
 
 
             switch (gateway) {
                 case "stripe":
-                par1 = getParam(argss, "stripe:version");
-                par2 = getParam(argss, "stripe:publishableKey");
+                par1 = getParam(argss, "version");
+                par2 = getParam(argss, "publishableKey");
                 break;
                 case "braintree":
-                par1 = getParam(argss, "braintree:apiVersion");
-                par2 = getParam(argss, "braintree:sdkVersion");
-                par3 = getParam(argss, "braintree:clientKey");
+                par1 = getParam(argss, "apiVersion");
+                par2 = getParam(argss, "sdkVersion");
+                par3 = getParam(argss, "clientKey");
                 break;
                 case "vantiv":
-                par1 = getParam(argss, "vantiv:merchantPayPageId");
-                par2 = getParam(argss, "vantiv:merchantOrderId");
-                par3 = getParam(argss, "vantiv:merchantTransactionId");
+                par1 = getParam(argss, "merchantPayPageId");
+                par2 = getParam(argss, "merchantOrderId");
+                par3 = getParam(argss, "merchantTransactionId");
                 break;
             }
 
@@ -202,7 +202,7 @@ public class ApplePayGooglePay extends CordovaPlugin {
      * @see <a href=
      * "https://developers.google.com/pay/api/android/reference/object#PaymentMethodTokenizationSpecification">PaymentMethodTokenizationSpecification</a>
      */
-    private static JSONObject getGatewayTokenizationSpecification(String gateway, String gatewayMerchantId, JSONObject argss) throws JSONException {
+    private static JSONObject getGatewayTokenizationSpecification(String gateway, String gatewayMerchantId, String par1, String par2, String par3) throws JSONException {
         switch (gateway) {
             case "stripe":
             return new JSONObject() {{


### PR DESCRIPTION
There are a few parameters missing to process Stripe, Braintree, and Vantiv payments. Parameter info can be found here: https://developers.google.com/pay/api/android/reference/request-objects#PaymentMethodTokenizationSpecification

Made the corresponding changes.